### PR TITLE
Add openapi org id to config for authentication

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -8,6 +8,7 @@ MONGO_USERNAME="bugstorm1000"
 MONGO_PASSWORD=""
 
 # OpenAI env vars
+OPEN_AI_ORG_ID=
 OPEN_AI_API_KEY=
 GPT_MODEL=gpt-3.5-turbo # gpt-4 for better responses
 ```

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -21,6 +21,7 @@ const config = {
   },
   openaiApiKey: process.env.OPENAI_API_KEY,
   openaiConfig: new Configuration({
+    organization: process.env.OPEN_AI_ORG_ID,
     apiKey: process.env.OPEN_AI_API_KEY || 'add-alt-key-here',
   }),
 }


### PR DESCRIPTION
**Problem:**

- teammate had issue where `Default org` on [Openapi User -> API Key Settings ](https://platform.openai.com/account/api-keys) had to be changed from `Personal` to ---> `BugStormCPSC455` in the drop down.

     <img width="500" alt="Screenshot 2023-07-13 at 1 42 18 AM" src="https://github.com/cpsc455-bugstorm/TravelersTea/assets/59987667/50b6cf48-bd76-45d4-a314-591de372f682">

- I got a similar 401 bug (not authorized due to Default org being 'Personal') after creating few test keys to replicate teammate's bug

**Solution:**

- We can pass org id to configurations. org id found [here](https://platform.openai.com/account/org-settings)  + [documentation](https://platform.openai.com/docs/api-reference/authentication) for authentication changes

     <img width="385" alt="Screenshot 2023-07-13 at 1 47 50 AM" src="https://github.com/cpsc455-bugstorm/TravelersTea/assets/59987667/1f97c9e0-76b0-4002-ab0a-3838d57b1dbb">



- This is useful incase in the future someone accidentally forgets the dropdown stuff or has multiple orgs