### PR TITLE
Trip creation error fixes

### DIFF
--- a/client/src/SessionController.js
+++ b/client/src/SessionController.js
@@ -19,7 +19,7 @@ import {
   updateAsLoggedIn,
   updateAsLoggedOut,
 } from './redux/reducers/users/usersSlice'
-import { resetView, setAppView } from './redux/reducers/viewSlice'
+import { openSidebar, resetView, setAppView } from './redux/reducers/viewSlice'
 import { REQUEST_STATE } from './redux/states'
 
 SessionController.propTypes = {
@@ -111,7 +111,9 @@ export function SessionController({ children }) {
     if (tripsStates.error) {
       setAlertMessage(tripsStates.error)
       setAlertOpen(true)
+      setIsLoading(false)
       dispatch(clearTripsError())
+      dispatch(openSidebar())
     }
   }, [dispatch, tripsStates.error])
 
@@ -119,7 +121,9 @@ export function SessionController({ children }) {
     if (stagesStates.error) {
       setAlertMessage(stagesStates.error)
       setAlertOpen(true)
+      setIsLoading(false)
       dispatch(clearStagesError())
+      dispatch(openSidebar())
     }
   }, [dispatch, stagesStates.error])
 
@@ -129,6 +133,7 @@ export function SessionController({ children }) {
         setAlertMessage('Error: Invalid Credentials')
         setAlertOpen(true)
         dispatch(clearUserError())
+        setIsLoading(false)
       }, 2500)
     }
   }, [dispatch, userStates.error])

--- a/server/controllers/TripController.js
+++ b/server/controllers/TripController.js
@@ -16,10 +16,10 @@ class TripController {
   }
 
   async getAll(userId) {
+    if (!userId) {
+      throw new Error('User ID is required to fetch trips.')
+    }
     try {
-      if (!userId) {
-        throw new Error('User ID is required to fetch trips.')
-      }
       return await TripModel.find({ userId }).lean()
     } catch (error) {
       throw new Error(`Could not fetch all trips: ${error}`)
@@ -66,9 +66,15 @@ class TripController {
   }
 
   async createTrip(userId, tripData) {
+    let generatedTripWithStages
     try {
-      const generatedTripWithStagesJSON = await generateTrip(tripData)
-      const generatedTripWithStages = JSON.parse(generatedTripWithStagesJSON)
+      generatedTripWithStages = await generateTrip(tripData)
+    } catch (e) {
+      console.error('Error while generating itinerary:', e)
+      throw e
+    }
+
+    try {
       const longLatObject = await getCoordinatesFromLocation(
         '',
         tripData.tripLocation,


### PR DESCRIPTION
Changes
- generateTrip returns an object
- generateTrip directly throws errors
- When error is caught, set `isLoading` to false, and open the sidebar. 
- Generate a total of 25 stages max (instead of 5 days with 5 stages each)

Closes #178 

Test that 
- Creating valid new trip works
- Creating new trip with invalid location (e.g. put a random sentence) should gracefully fail
- Creating new trip with invalid OpenAI API token should gracefully fail
