### PR TITLE
Improve api responses and cache destinations

### DIFF
--- a/client/src/SessionController.js
+++ b/client/src/SessionController.js
@@ -24,7 +24,10 @@ import {
   flagAsFulfilled,
   resetTrips,
 } from './redux/reducers/trips/tripsSlice'
-import { fetchLimitLeftAsync } from './redux/reducers/users/thunks'
+import {
+  fetchEFLimitLeftAsync,
+  fetchLimitLeftAsync,
+} from './redux/reducers/users/thunks'
 import {
   clearUserError,
   updateAsLoggedIn,
@@ -143,13 +146,14 @@ export function SessionController() {
         stagesStates.status === REQUEST_STATE.REJECTED ||
         stagesStates.status === REQUEST_STATE.IDLE)
     ) {
-      delaySetLoadingFalse(1000)
+      delaySetLoadingFalse(1000, () => dispatch(fetchEFLimitLeftAsync()))
     }
-  }, [tripsStates.status, stagesStates.status])
+  }, [tripsStates.status, stagesStates.status, dispatch])
 
   useEffect(() => {
     if (userStates.status === REQUEST_STATE.LOGGINGIN) {
       dispatch(fetchLimitLeftAsync())
+      dispatch(fetchEFLimitLeftAsync())
       delaySetLoadingFalse(2500, () => {
         dispatch(updateAsLoggedIn())
         dispatch(setLightMode(shouldUseLightMode()))

--- a/client/src/SessionController.js
+++ b/client/src/SessionController.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
+import App from './App'
 import { Loader } from './components/common'
 import { SideBar } from './components/sideBar'
 import { AppView } from './constants/enums'
@@ -31,7 +32,6 @@ import {
 } from './redux/reducers/users/usersSlice'
 import { openSidebar, resetView, setAppView } from './redux/reducers/viewSlice'
 import { REQUEST_STATE } from './redux/states'
-import App from './App'
 import { shouldUseLightMode } from './util/lightMode'
 
 SessionController.propTypes = {
@@ -52,6 +52,19 @@ export function SessionController() {
   const delaySetLoadingFalse = (ms, callback = () => {}) => {
     setTimeout(() => {
       setIsLoading(false)
+      callback()
+    }, ms)
+  }
+  const [isLimitAlertOpen, setIsLimitAlertOpen] = useState(false)
+  const delaySetLimitAlertFalse = (ms, callback = () => {}) => {
+    setTimeout(() => {
+      setIsLimitAlertOpen(false)
+      callback()
+    }, ms)
+  }
+  const delaySetLimitAlertTrue = (ms, callback = () => {}) => {
+    setTimeout(() => {
+      setIsLimitAlertOpen(true)
       callback()
     }, ms)
   }
@@ -175,27 +188,28 @@ export function SessionController() {
 
   useEffect(() => {
     if (
-      modalStates.newTripModalIsOpen ||
-      modalStates.editStageModalIsOpen ||
-      modalStates.editTripModalIsOpen
+      !isLimitAlertOpen &&
+      userStates.status === REQUEST_STATE.LOGGEDIN &&
+      (modalStates.newTripModalIsOpen ||
+        modalStates.editStageModalIsOpen ||
+        modalStates.editTripModalIsOpen)
     ) {
-      enqueueSnackbar(
-        `You have ${userStates.attemptLeft} trip creation/update requests left today`,
-        { variant: userStates.attemptLeft > 3 ? 'info' : 'warning' },
-      )
+      dispatch(fetchLimitLeftAsync())
+      delaySetLimitAlertTrue(500)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modalStates, enqueueSnackbar])
+  }, [modalStates, userStates.status])
 
   useEffect(() => {
-    if (userStates.status === REQUEST_STATE.LOGGEDIN) {
+    if (userStates.status === REQUEST_STATE.LOGGEDIN && isLimitAlertOpen) {
       enqueueSnackbar(
         `You have ${userStates.attemptLeft} trip creation/update requests left today`,
         { variant: userStates.attemptLeft > 3 ? 'info' : 'warning' },
       )
+      delaySetLimitAlertFalse(5000)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enqueueSnackbar, userStates.status])
+  }, [isLimitAlertOpen, enqueueSnackbar])
 
   useEffect(() => {
     let timer

--- a/client/src/components/TripElement/CompressedForm.js
+++ b/client/src/components/TripElement/CompressedForm.js
@@ -1,12 +1,15 @@
+import LockClockTwoToneIcon from '@mui/icons-material/LockClockTwoTone'
 import TravelExploreIcon from '@mui/icons-material/TravelExplore'
-import { InputAdornment, TextField } from '@mui/material'
+import { InputAdornment, TextField, Tooltip } from '@mui/material'
 import PropTypes from 'prop-types'
+import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { SLOWER_SPEED, ZOOM_GLOBE_LEVEL } from '../../constants/mapDefaultInfo'
 import { changeSpeed, changeZoom } from '../../redux/reducers/mapSlice'
-import { Button } from '../common'
 import { setActiveDayNumber } from '../../redux/reducers/viewSlice'
+import { getBlackWhite } from '../../util/lightMode'
+import { Button, Modal } from '../common'
 
 CompressedForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
@@ -14,6 +17,23 @@ CompressedForm.propTypes = {
 
 export function CompressedForm({ onSubmit }) {
   const dispatch = useDispatch()
+  const efLimit = useSelector((state) => state.users.efAttemptLeft)
+  const [openModal, setOpenModal] = useState(false)
+  const isLightMode = useSelector((state) => state.preferences.lightMode)
+  const closeModal = () => {
+    setOpenModal(false)
+  }
+  const textColor = useMemo(
+    () => getBlackWhite(isLightMode, 'text', 'white'),
+    [isLightMode],
+  )
+  const handleOpenModal = () => {
+    setOpenModal(true)
+  }
+  const handleConfirmSubmit = () => {
+    handleSubmit(onSubmitForm)()
+    closeModal()
+  }
 
   const {
     register,
@@ -29,36 +49,91 @@ export function CompressedForm({ onSubmit }) {
   }
 
   return (
-    <div className='flex w-full flex-row'>
-      <form
-        onSubmit={handleSubmit(onSubmitForm)}
-        className='flex w-full flex-col space-y-4 text-center'
+    <>
+      <div className='flex w-full flex-row'>
+        <form
+          onSubmit={handleSubmit(() => {})}
+          className='flex w-full flex-col space-y-4 text-center'
+        >
+          <TextField
+            disabled={efLimit <= 0}
+            className={`w-full ${
+              efLimit <= 0
+                ? 'bg-gray-200 text-gray-400 placeholder-gray-400'
+                : ''
+            }`}
+            InputProps={{
+              startAdornment:
+                efLimit <= 0 ? (
+                  <Tooltip
+                    title='You have ran out of this feature for the day'
+                    placement='bottom-start'
+                    arrow
+                  >
+                    <InputAdornment position='start'>
+                      <LockClockTwoToneIcon />
+                    </InputAdornment>
+                  </Tooltip>
+                ) : (
+                  <Tooltip
+                    title='Make any requests once per day'
+                    placement='bottom-start'
+                    arrow
+                  >
+                    <InputAdornment position='start'>
+                      <TravelExploreIcon />
+                    </InputAdornment>
+                  </Tooltip>
+                ),
+              endAdornment: efLimit > 0 && (
+                <InputAdornment position='end'>
+                  <Button
+                    padding='p-1'
+                    className='w-full rounded bg-slate-300 hover:bg-slate-400'
+                    type='button'
+                    onClick={handleOpenModal}
+                  >
+                    Brew 🍵
+                  </Button>
+                </InputAdornment>
+              ),
+            }}
+            {...register('colloquialPrompt', { required: true })}
+            placeholder='Tell me your plan...'
+            error={!!errors.colloquialPrompt}
+          />
+        </form>
+      </div>
+      <Modal
+        open={openModal}
+        handleClose={closeModal}
+        footer={
+          <>
+            <Button
+              onClick={closeModal}
+              className={`bg-slate-800/60 hover:bg-slate-600/60 ${textColor}`}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirmSubmit}
+              className={`bg-red-800/90 hover:bg-red-600/90 ${textColor}`}
+            >
+              Confirm
+            </Button>
+          </>
+        }
+        title={'Confirmation'}
+        titleSize='text-3xl'
+        modalSize='sm'
+        classNameContent={'mx-20'}
       >
-        <TextField
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position='start'>
-                <TravelExploreIcon />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <InputAdornment position='end'>
-                <Button
-                  padding='p-1'
-                  className='w-full rounded bg-slate-300 hover:bg-slate-400'
-                  type='submit'
-                  onClick={() => {}}
-                >
-                  Brew 🍵
-                </Button>
-              </InputAdornment>
-            ),
-          }}
-          {...register('colloquialPrompt', { required: true })}
-          placeholder='Tell me your plan...'
-          error={!!errors.colloquialPrompt}
-        />
-      </form>
-    </div>
+        <p>
+          One of the Extra Notes or Speak Your Mind feature can be used once a
+          day.
+          <br /> Do you want to submit?
+        </p>
+      </Modal>
+    </>
   )
 }

--- a/client/src/components/TripElement/EditStageForm.js
+++ b/client/src/components/TripElement/EditStageForm.js
@@ -1,10 +1,9 @@
+import { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { closeEditStageModal } from '../../redux/reducers/modalsSlice'
+import { updateStageAsync } from '../../redux/reducers/stage/thunks'
 import { Modal } from '../common'
 import { StageForm } from './StageForm'
-import { updateStageAsync } from '../../redux/reducers/stage/thunks'
-import { useEffect, useRef } from 'react'
-import { decrementAttemptsLeft } from '../../redux/reducers/users/usersSlice'
 
 export function EditStageForm() {
   const dispatch = useDispatch()
@@ -36,9 +35,7 @@ export function EditStageForm() {
           id: updateData.stage._id,
           updateData: { ...updateData, trip: activeTripRef.current },
         }),
-      )
-        .unwrap()
-        .then(() => dispatch(decrementAttemptsLeft()))
+      ).unwrap()
     } catch (error) {
       console.error(error)
     }

--- a/client/src/components/TripElement/EditTripForm.js
+++ b/client/src/components/TripElement/EditTripForm.js
@@ -6,7 +6,6 @@ import { DEFAULT_SPEED, ZOOM_CITY_LEVEL } from '../../constants/mapDefaultInfo'
 import { changeCoordinatesAndZoom } from '../../redux/reducers/mapSlice'
 import { closeEditTripModal } from '../../redux/reducers/modalsSlice'
 import { updateTripAsync } from '../../redux/reducers/trips/thunks'
-import { decrementAttemptsLeft } from '../../redux/reducers/users/usersSlice'
 import { Modal } from '../common'
 import { CompressedForm } from './CompressedForm'
 import { TripForm } from './TripForm'
@@ -60,7 +59,6 @@ export function EditTripForm() {
           speed: DEFAULT_SPEED,
         }),
       )
-      dispatch(decrementAttemptsLeft())
     } catch (error) {
       console.error(error)
     }

--- a/client/src/components/TripElement/NewTripForm.js
+++ b/client/src/components/TripElement/NewTripForm.js
@@ -7,7 +7,6 @@ import { DEFAULT_SPEED, ZOOM_CITY_LEVEL } from '../../constants/mapDefaultInfo'
 import { changeCoordinatesAndZoom } from '../../redux/reducers/mapSlice'
 import { closeNewTripModal } from '../../redux/reducers/modalsSlice'
 import { createTripAsync } from '../../redux/reducers/trips/thunks'
-import { decrementAttemptsLeft } from '../../redux/reducers/users/usersSlice'
 import { setActiveTripId, setAppView } from '../../redux/reducers/viewSlice'
 import { Modal } from '../common'
 import { CompressedForm } from './CompressedForm'
@@ -49,7 +48,6 @@ export function NewTripForm() {
       )
       dispatch(setAppView(AppView.TRIP_VIEW))
       dispatch(setActiveTripId(newTrip._id))
-      dispatch(decrementAttemptsLeft())
     } catch (error) {
       console.error(error)
     }

--- a/client/src/components/TripElement/TripForm.js
+++ b/client/src/components/TripElement/TripForm.js
@@ -1,11 +1,12 @@
-import { TextField } from '@mui/material'
+import LockClockTwoToneIcon from '@mui/icons-material/LockClockTwoTone'
+import { InputAdornment, TextField, Tooltip } from '@mui/material'
 import PropTypes from 'prop-types'
 import { useForm } from 'react-hook-form'
 import { useDispatch } from 'react-redux'
 import { SLOWER_SPEED, ZOOM_GLOBE_LEVEL } from '../../constants/mapDefaultInfo'
 import { changeSpeed, changeZoom } from '../../redux/reducers/mapSlice'
-import { Button } from '../common'
 import { setActiveDayNumber } from '../../redux/reducers/viewSlice'
+import { Button } from '../common'
 
 TripForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
@@ -70,11 +71,28 @@ export function TripForm({ onSubmit, initialValues = {} }) {
         inputProps={{ min: 0 }}
         error={!!errors.numberOfDays}
       />
-      <TextField
-        {...register('tripNotes', { required: false })}
-        label='Extra Notes'
-        placeholder='Tell me what you would like...'
-      />
+      <Tooltip
+        title="You don't have permission to do this"
+        placement='bottom-start'
+        arrow
+        followCursor
+      >
+        <TextField
+          className='w-full bg-gray-200 text-gray-400 placeholder-gray-400'
+          disabled
+          {...register('tripNotes', { required: false })}
+          label='Extra Notes'
+          placeholder='Tell me what you would like...'
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position='start'>
+                <LockClockTwoToneIcon />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Tooltip>
+
       <Button
         className='mt-4 w-full rounded bg-slate-300 hover:bg-slate-400'
         type='submit'

--- a/client/src/components/TripElement/TripForm.js
+++ b/client/src/components/TripElement/TripForm.js
@@ -2,12 +2,14 @@ import InfoTwoToneIcon from '@mui/icons-material/InfoTwoTone'
 import LockClockTwoToneIcon from '@mui/icons-material/LockClockTwoTone'
 import { InputAdornment, TextField, Tooltip } from '@mui/material'
 import PropTypes from 'prop-types'
+import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { SLOWER_SPEED, ZOOM_GLOBE_LEVEL } from '../../constants/mapDefaultInfo'
 import { changeSpeed, changeZoom } from '../../redux/reducers/mapSlice'
 import { setActiveDayNumber } from '../../redux/reducers/viewSlice'
-import { Button } from '../common'
+import { getBlackWhite } from '../../util/lightMode'
+import { Button, Modal } from '../common'
 
 TripForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
@@ -18,10 +20,27 @@ export function TripForm({ onSubmit, initialValues = {} }) {
   const dispatch = useDispatch()
   const efLimit = useSelector((state) => state.users.efAttemptLeft)
   const lastEnteredNote = localStorage.getItem('lastEnteredNote')
+  const [openModal, setOpenModal] = useState(false)
+  const isLightMode = useSelector((state) => state.preferences.lightMode)
+  const closeModal = () => {
+    setOpenModal(false)
+  }
+  const textColor = useMemo(
+    () => getBlackWhite(isLightMode, 'text', 'white'),
+    [isLightMode],
+  )
+  const handleOpenModal = () => {
+    setOpenModal(true)
+  }
+  const handleConfirmSubmit = () => {
+    handleSubmit(onSubmitForm)()
+    closeModal()
+  }
 
   const {
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm({
     defaultValues: {
@@ -35,53 +54,45 @@ export function TripForm({ onSubmit, initialValues = {} }) {
     dispatch(changeZoom(ZOOM_GLOBE_LEVEL))
     dispatch(changeSpeed(SLOWER_SPEED))
     dispatch(setActiveDayNumber(-1))
-    onSubmit(data)
+    onSubmit(efLimit <= 0 ? { ...data, tripNotes: '' } : data)
   }
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmitForm)}
-      className='flex flex-col space-y-4 text-center'
-    >
-      <TextField
-        {...register('tripLocation', { required: true })}
-        label='Destination'
-        placeholder='Tell me where you want to go...'
-        error={!!errors.tripLocation}
-      />
-      <TextField
-        {...register('stagesPerDay', { required: true, min: 0 })}
-        label='Places per Day'
-        placeholder='Tell me how many places you want to visit...'
-        type='number'
-        inputProps={{ min: 0 }}
-        error={!!errors.stagesPerDay}
-      />
-      <TextField
-        {...register('budget', { required: true, min: 0 })}
-        label='Budget per Day ($)'
-        placeholder='Tell me how much you want to spend...'
-        type='number'
-        inputProps={{ min: 0 }}
-        error={!!errors.budget}
-      />
-      <TextField
-        {...register('numberOfDays', { required: true, min: 0 })}
-        label='Number of Days'
-        placeholder='Tell me how long you are going for...'
-        type='number'
-        inputProps={{ min: 0 }}
-        error={!!errors.numberOfDays}
-      />
-      <Tooltip
-        title='You have ran out of this feature for the day, this will not be applied to your next trip'
-        placement='bottom-start'
-        arrow
-        followCursor
-        disableFocusListener
-        disableHoverListener={efLimit >= 1}
-        disableTouchListener
+    <>
+      <form
+        onSubmit={handleSubmit(() => {})}
+        className='flex flex-col space-y-4 text-center'
       >
+        <TextField
+          {...register('tripLocation', { required: true })}
+          label='Destination'
+          placeholder='Tell me where you want to go...'
+          error={!!errors.tripLocation}
+        />
+        <TextField
+          {...register('stagesPerDay', { required: true, min: 0 })}
+          label='Places per Day'
+          placeholder='Tell me how many places you want to visit...'
+          type='number'
+          inputProps={{ min: 0 }}
+          error={!!errors.stagesPerDay}
+        />
+        <TextField
+          {...register('budget', { required: true, min: 0 })}
+          label='Budget per Day ($)'
+          placeholder='Tell me how much you want to spend...'
+          type='number'
+          inputProps={{ min: 0 }}
+          error={!!errors.budget}
+        />
+        <TextField
+          {...register('numberOfDays', { required: true, min: 0 })}
+          label='Number of Days'
+          placeholder='Tell me how long you are going for...'
+          type='number'
+          inputProps={{ min: 0 }}
+          error={!!errors.numberOfDays}
+        />
         <TextField
           className={`w-full ${
             efLimit <= 0 ? 'bg-gray-200 text-gray-400 placeholder-gray-400' : ''
@@ -93,9 +104,15 @@ export function TripForm({ onSubmit, initialValues = {} }) {
           InputProps={{
             startAdornment:
               efLimit <= 0 ? (
-                <InputAdornment position='start'>
-                  <LockClockTwoToneIcon />
-                </InputAdornment>
+                <Tooltip
+                  title='You have ran out of this feature for the day, this will not be applied to your next trip'
+                  placement='bottom-start'
+                  arrow
+                >
+                  <InputAdornment position='start'>
+                    <LockClockTwoToneIcon />
+                  </InputAdornment>
+                </Tooltip>
               ) : (
                 <Tooltip
                   title='You have one use of Extra Notes or Speak Your Mind per day'
@@ -109,15 +126,54 @@ export function TripForm({ onSubmit, initialValues = {} }) {
               ),
           }}
         />
-      </Tooltip>
+        <Button
+          className='mt-4 w-full rounded bg-slate-300 hover:bg-slate-400'
+          type='button'
+          onClick={() => {
+            const formValues = getValues()
+            const hasTripNotes =
+              formValues.tripNotes && formValues.tripNotes.trim() !== ''
 
-      <Button
-        className='mt-4 w-full rounded bg-slate-300 hover:bg-slate-400'
-        type='submit'
-        onClick={() => {}}
+            if (efLimit <= 0 || !hasTripNotes) {
+              handleSubmit(onSubmitForm)()
+            } else {
+              handleOpenModal()
+            }
+          }}
+        >
+          Brew 🍵
+        </Button>
+      </form>
+      <Modal
+        open={openModal}
+        handleClose={closeModal}
+        footer={
+          <>
+            <Button
+              onClick={closeModal}
+              className={`bg-slate-800/60 hover:bg-slate-600/60 ${textColor}`}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirmSubmit}
+              className={`bg-red-800/90 hover:bg-red-600/90 ${textColor}`}
+            >
+              Confirm
+            </Button>
+          </>
+        }
+        title={'Confirmation'}
+        titleSize='text-3xl'
+        modalSize='sm'
+        classNameContent={'mx-20'}
       >
-        Brew 🍵
-      </Button>
-    </form>
+        <p>
+          One of the Extra Notes or Speak Your Mind feature can be used once a
+          day.
+          <br /> Do you want to submit?
+        </p>
+      </Modal>
+    </>
   )
 }

--- a/client/src/components/TripElement/TripForm.js
+++ b/client/src/components/TripElement/TripForm.js
@@ -1,8 +1,9 @@
+import InfoTwoToneIcon from '@mui/icons-material/InfoTwoTone'
 import LockClockTwoToneIcon from '@mui/icons-material/LockClockTwoTone'
 import { InputAdornment, TextField, Tooltip } from '@mui/material'
 import PropTypes from 'prop-types'
 import { useForm } from 'react-hook-form'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { SLOWER_SPEED, ZOOM_GLOBE_LEVEL } from '../../constants/mapDefaultInfo'
 import { changeSpeed, changeZoom } from '../../redux/reducers/mapSlice'
 import { setActiveDayNumber } from '../../redux/reducers/viewSlice'
@@ -15,6 +16,7 @@ TripForm.propTypes = {
 
 export function TripForm({ onSubmit, initialValues = {} }) {
   const dispatch = useDispatch()
+  const efLimit = useSelector((state) => state.users.efAttemptLeft)
   const lastEnteredNote = localStorage.getItem('lastEnteredNote')
 
   const {
@@ -72,23 +74,39 @@ export function TripForm({ onSubmit, initialValues = {} }) {
         error={!!errors.numberOfDays}
       />
       <Tooltip
-        title="You don't have permission to do this"
+        title='You have ran out of this feature for the day, this will not be applied to your next trip'
         placement='bottom-start'
         arrow
         followCursor
+        disableFocusListener
+        disableHoverListener={efLimit >= 1}
+        disableTouchListener
       >
         <TextField
-          className='w-full bg-gray-200 text-gray-400 placeholder-gray-400'
-          disabled
+          className={`w-full ${
+            efLimit <= 0 ? 'bg-gray-200 text-gray-400 placeholder-gray-400' : ''
+          }`}
+          disabled={efLimit <= 0}
           {...register('tripNotes', { required: false })}
           label='Extra Notes'
           placeholder='Tell me what you would like...'
           InputProps={{
-            startAdornment: (
-              <InputAdornment position='start'>
-                <LockClockTwoToneIcon />
-              </InputAdornment>
-            ),
+            startAdornment:
+              efLimit <= 0 ? (
+                <InputAdornment position='start'>
+                  <LockClockTwoToneIcon />
+                </InputAdornment>
+              ) : (
+                <Tooltip
+                  title='You have one use of Extra Notes or Speak Your Mind per day'
+                  placement='bottom-start'
+                  arrow
+                >
+                  <InputAdornment position='start'>
+                    <InfoTwoToneIcon />
+                  </InputAdornment>
+                </Tooltip>
+              ),
           }}
         />
       </Tooltip>

--- a/client/src/redux/reducers/users/actionTypes.js
+++ b/client/src/redux/reducers/users/actionTypes.js
@@ -3,4 +3,5 @@ export const actionTypes = {
   LOGIN_USER: 'users/loginUser',
   LOGOUT_USER: 'users/logoutUser',
   FETCH_LIMIT: 'users/limit-left',
+  FETCH_EF_LIMIT: 'users/ef-limit-left',
 }

--- a/client/src/redux/reducers/users/service.js
+++ b/client/src/redux/reducers/users/service.js
@@ -5,6 +5,10 @@ export const fetchLimit = async () => {
   return await axios.get(`${API_URL}/users/limit-left`, {})
 }
 
+export const fetchEFLimit = async () => {
+  return await axios.get(`${API_URL}/users/ef-limit-left`, {})
+}
+
 export const registerUser = async (userData) => {
   return await axios.post(`${API_URL}/users/register`, userData)
 }
@@ -15,6 +19,7 @@ export const loginUser = async (userData) => {
 
 const usersService = {
   fetchLimit,
+  fetchEFLimit,
   registerUser,
   loginUser,
 }

--- a/client/src/redux/reducers/users/thunks.js
+++ b/client/src/redux/reducers/users/thunks.js
@@ -16,6 +16,20 @@ export const fetchLimitLeftAsync = createAsyncThunk(
   },
 )
 
+export const fetchEFLimitLeftAsync = createAsyncThunk(
+  actionTypes.FETCH_EF_LIMIT,
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await usersService.fetchEFLimit()
+      return response.data
+    } catch (error) {
+      return rejectWithValue({
+        message: error.response.data.error || error.response.data,
+      })
+    }
+  },
+)
+
 export const registerUserAsync = createAsyncThunk(
   actionTypes.REGISTER_USER,
   async (userData, { rejectWithValue }) => {

--- a/client/src/redux/reducers/users/usersSlice.js
+++ b/client/src/redux/reducers/users/usersSlice.js
@@ -3,6 +3,7 @@ import { handleAsyncAction } from '../../handleAsync'
 import { REQUEST_STATE } from '../../states'
 import {
   fetchLimitLeftAsync,
+  fetchEFLimitLeftAsync,
   loginUserAsync,
   registerUserAsync,
 } from './thunks'
@@ -35,6 +36,7 @@ export const usersSlice = createSlice({
     error: null,
     isNewAccount: false,
     attemptLeft: null,
+    efAttemptLeft: null,
   },
   reducers: {
     updateAsLoggedOut: (state) => {
@@ -61,6 +63,15 @@ export const usersSlice = createSlice({
       },
       rejected: (state) => {
         state.attemptLeft = 0
+      },
+    })
+    handleAsyncAction(builder, fetchEFLimitLeftAsync, {
+      pending: () => {},
+      fulfilled: (state, action) => {
+        state.efAttemptLeft = action.payload.efAttemptLeft
+      },
+      rejected: (state) => {
+        state.efAttemptLeft = 0
       },
     })
     handleAsyncAction(builder, registerUserAsync, {

--- a/client/src/redux/reducers/users/usersSlice.js
+++ b/client/src/redux/reducers/users/usersSlice.js
@@ -52,9 +52,6 @@ export const usersSlice = createSlice({
     clearUserError: (state) => {
       state.error = null
     },
-    decrementAttemptsLeft: (state) => {
-      state.attemptLeft = state.attemptLeft - 1
-    },
   },
   extraReducers: (builder) => {
     handleAsyncAction(builder, fetchLimitLeftAsync, {
@@ -97,7 +94,6 @@ export const {
   updateAsLoggedOut,
   updateAsLoggedIn,
   clearUserError,
-  decrementAttemptsLeft,
 } = usersSlice.actions
 
 export default usersSlice.reducer

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "reset:db": "yarn workspace server reset:db",
     "populate:db": "yarn workspace server populate:db",
     "dupe:db": "yarn workspace server dupe:db",
+    "cache:db": "yarn workspace server cache:db",
     "clean:db": "yarn workspace server clean:db",
     "lint": "eslint .",
     "lint:fix": "eslint . --cache --fix",

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -12,6 +12,7 @@ const JWT_SECRET = process.env.JWT_SECRET || ''
 const CLIENT_URL = process.env.CLIENT_URL
 
 const RATE_LIMIT = process.env.RATE_LIMIT || 10
+const EF_RATE_LIMIT = process.env.EF_RATE_LIMIT || 1
 const PROXY = process.env.PROXY || 1
 const TIME_LIMT = process.env.TIME_LIMT || 24 * 60 * 60 * 1000 // 1 day
 
@@ -27,6 +28,7 @@ const config = {
     jwtSecret: JWT_SECRET,
     clientURL: CLIENT_URL,
     rateLimit: RATE_LIMIT,
+    efRateLimit: EF_RATE_LIMIT,
     proxy: PROXY,
     timeLimit: TIME_LIMT,
   },

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -1,0 +1,57 @@
+const DestinationModel = require('../models/DestinationModel')
+const FuzzySearch = require('fuzzy-search')
+
+class DestinationController {
+  async searchDestination(query) {
+    try {
+      // Fetch all destinations
+      const destinations = await DestinationModel.find().lean()
+
+      // Extract names and aliases
+      const namesAndAliases = destinations.flatMap((destination) => [
+        destination.name,
+        ...(destination.alias || []),
+      ])
+
+      // Perform a fuzzy search on the names and aliases
+      const searcher = new FuzzySearch(namesAndAliases)
+      const results = searcher.search(query)
+
+      // Return the destinations that match the search results
+      const matchingDestinations = destinations.filter(
+        (destination) =>
+          results.includes(destination.name) ||
+          (destination.alias || []).some((alias) => results.includes(alias)),
+      )
+
+      return matchingDestinations
+    } catch (error) {
+      error.message = 'Could not search destination | ' + error.message
+      throw error
+    }
+  }
+
+  async findClosestDestinations(latitude, longitude, n) {
+    try {
+      const closestDestinations = await DestinationModel.find({
+        location: {
+          $near: {
+            $geometry: {
+              type: 'Point',
+              coordinates: [longitude, latitude],
+            },
+          },
+        },
+      })
+        .limit(n)
+        .lean()
+
+      return closestDestinations
+    } catch (error) {
+      error.message = 'Could not find closest destinations | ' + error.message
+      throw error
+    }
+  }
+}
+
+module.exports = DestinationController

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -1,5 +1,6 @@
 const DestinationModel = require('../models/DestinationModel')
 const getLatLon = require('../googleapi/getLatLon')
+const generateTrip = require('../openai/generateTrip')
 const nlp = require('compromise')
 const FuzzySearch = require('fuzzy-search')
 
@@ -34,44 +35,6 @@ class DestinationController {
     }
   }
 
-  async tryCache(tripData) {
-    const tripLatLon = await getLatLon(tripData.tripLocation)
-    const cachedDestinations = await this.findClosestDestinations(
-      tripLatLon.lat,
-      tripLatLon.lng,
-      tripData.numberOfDays * tripData.stagesPerDay,
-    )
-    if (
-      cachedDestinations.length >=
-      tripData.numberOfDays * tripData.stagesPerDay
-    ) {
-      return {
-        days: Array.from({ length: tripData.numberOfDays }, (_, dayIndex) => ({
-          day: dayIndex + 1,
-          stages: Array.from(
-            { length: tripData.stagesPerDay },
-            (_, stageIndex) => {
-              const destination =
-                cachedDestinations[
-                  dayIndex * tripData.stagesPerDay + stageIndex
-                ]
-              return {
-                stageIndex: stageIndex + 1,
-                stageLocationName: destination.alias
-                  ? destination.alias[0]
-                  : destination.name,
-                stageDescription: destination.description,
-                stageEmoji: destination.emoji,
-              }
-            },
-          ),
-        })),
-      }
-    } else {
-      return null
-    }
-  }
-
   async findClosestDestinations(latitude, longitude, n) {
     try {
       const milesToMeters = 1609.34 // Conversion factor
@@ -98,6 +61,15 @@ class DestinationController {
     }
   }
 
+  /**
+   * Caches a stage's information into the database.
+   * If the stage already exists, it updates the existing record.
+   * Otherwise, it creates a new record.
+   *
+   * @param {Object} stage - The stage object containing stage datas.
+   * @param {String} name - Whatever the user queried as 'destination'.
+   * @param {String} notes - Extra notes.
+   */
   async cacheStage(stage, name, notes) {
     try {
       const existingDestination = await DestinationModel.findOne({
@@ -123,6 +95,7 @@ class DestinationController {
           description: stage.description,
           emoji: stage.emoji,
           tag: tags,
+          rating: stage.stageRating,
         }
 
         await DestinationModel.create(newDestination)
@@ -157,6 +130,133 @@ class DestinationController {
     nouns = nouns.filter((word) => !stopWords.includes(word.toLowerCase()))
 
     return nouns
+  }
+
+  /**
+   * Generates a trip itinerary by combining cached and newly generated stages.
+   * It first tries to fetch up to 80% of the whole trip as cached stages based on the trip data.
+   * Then, it generates the remaining stages while avoiding the cached locations.
+   * Finally, it combines both sets of stages into a single itinerary.
+   *
+   * @param {Object} tripData - The trip constraints and details.
+   * @returns {Object} - The combined itinerary with days and stages.
+   */
+  async generateTripWithCache(tripData) {
+    const cacheDestination = await this.tryCache(tripData)
+    const avoidLocations = []
+    // eslint-disable-next-line node/no-unsupported-features/es-syntax
+    const destinationLeftToFetch = { ...tripData }
+
+    if (cacheDestination) {
+      cacheDestination.days.forEach((day) => {
+        day.stages.forEach((stage) => {
+          avoidLocations.push(stage.stageLocationName)
+        })
+      })
+      const cachedStagesPerDay = cacheDestination.days[0].stages.length
+      destinationLeftToFetch.stagesPerDay =
+        tripData.stagesPerDay - cachedStagesPerDay
+    }
+
+    let generatedDestination
+    try {
+      generatedDestination = await generateTrip(
+        destinationLeftToFetch,
+        avoidLocations,
+      )
+    } catch (error) {
+      error.message = 'Error while generating trip | ' + error.message
+      throw error
+    }
+
+    return this.combineDestinations(
+      cacheDestination,
+      generatedDestination,
+      tripData.numberOfDays,
+    )
+  }
+
+  // use user's destination's coordinates to find cacheable destinations to use
+  async tryCache(tripData) {
+    const tripLatLon = await getLatLon(tripData.tripLocation)
+
+    const numberToFetch = Math.floor(
+      tripData.numberOfDays * tripData.stagesPerDay * 0.8,
+    )
+
+    const cachedDestinations = await this.findClosestDestinations(
+      tripLatLon.lat,
+      tripLatLon.lng,
+      numberToFetch,
+    )
+
+    const minStagesPerDay = Math.floor(
+      cachedDestinations.length / tripData.numberOfDays,
+    )
+
+    if (minStagesPerDay < 1) {
+      return null
+    }
+
+    let index = 0
+    return {
+      days: Array.from({ length: tripData.numberOfDays }, (_, dayIndex) => {
+        let stageIndex = 0
+        const stages = Array.from({ length: minStagesPerDay }, () => {
+          const destination = cachedDestinations[index++]
+          stageIndex++
+          return {
+            stageIndex: stageIndex,
+            stageLocationName: destination.alias
+              ? destination.alias[0]
+              : destination.name,
+            stageDescription: destination.description,
+            stageEmoji: destination.emoji,
+          }
+        })
+
+        return {
+          day: dayIndex + 1,
+          stages,
+        }
+      }),
+    }
+  }
+
+  combineDestinations(cachedData, generatedData, numberOfDays) {
+    const combinedDestinations = []
+
+    for (let i = 0; i < numberOfDays; i++) {
+      const cachedStages = cachedData
+        ? cachedData.days[i]
+          ? cachedData.days[i].stages
+          : []
+        : []
+      const generatedStages = generatedData.days[i]
+        ? generatedData.days[i].stages
+        : []
+
+      const combinedStages = []
+
+      const allStages = [...cachedStages, ...generatedStages]
+
+      allStages.forEach((stage, index) => {
+        combinedStages.push({
+          // eslint-disable-next-line node/no-unsupported-features/es-syntax
+          ...stage,
+          stageIndex: index + 1,
+        })
+      })
+
+      combinedDestinations.push({
+        day: i + 1,
+        stages: combinedStages,
+      })
+    }
+
+    return {
+      days: combinedDestinations,
+    }
   }
 }
 

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -1,6 +1,8 @@
+/* eslint-disable node/no-unsupported-features/es-syntax */
 const DestinationModel = require('../models/DestinationModel')
 const getLatLon = require('../googleapi/getLatLon')
-const generateTrip = require('../openai/generateTrip')
+// const generateTrip = require('../openai/generateTrip')
+const generateDestination = require('../openai/generateDestination')
 const nlp = require('compromise')
 const FuzzySearch = require('fuzzy-search')
 
@@ -132,6 +134,7 @@ class DestinationController {
     return nouns
   }
 
+  // TODO: if there is tripNotes, then generate all
   /**
    * Generates a trip itinerary by combining cached and newly generated stages.
    * It first tries to fetch up to 80% of the whole trip as cached stages based on the trip data.
@@ -144,23 +147,23 @@ class DestinationController {
   async generateTripWithCache(tripData) {
     const cacheDestination = await this.tryCache(tripData)
     const avoidLocations = []
-    // eslint-disable-next-line node/no-unsupported-features/es-syntax
     const destinationLeftToFetch = { ...tripData }
 
     if (cacheDestination) {
-      cacheDestination.days.forEach((day) => {
-        day.stages.forEach((stage) => {
-          avoidLocations.push(stage.stageLocationName)
-        })
+      cacheDestination.s.forEach((stage) => {
+        avoidLocations.push(stage.l)
       })
-      const cachedStagesPerDay = cacheDestination.days[0].stages.length
+      const cachedStagesCount = cacheDestination.s.length
+      const cachedStagesPerDay = Math.floor(
+        cachedStagesCount / tripData.numberOfDays,
+      )
       destinationLeftToFetch.stagesPerDay =
         tripData.stagesPerDay - cachedStagesPerDay
     }
 
     let generatedDestination
     try {
-      generatedDestination = await generateTrip(
+      generatedDestination = await generateDestination(
         destinationLeftToFetch,
         avoidLocations,
       )
@@ -170,9 +173,10 @@ class DestinationController {
     }
 
     return this.combineDestinations(
-      cacheDestination,
+      cacheDestination || { s: [] },
       generatedDestination,
       tripData.numberOfDays,
+      tripData.stagesPerDay,
     )
   }
 
@@ -180,79 +184,71 @@ class DestinationController {
   async tryCache(tripData) {
     const tripLatLon = await getLatLon(tripData.tripLocation)
 
-    const numberToFetch = Math.floor(
+    const maxStagesToFetch = Math.floor(
       tripData.numberOfDays * tripData.stagesPerDay * 0.8,
     )
 
     const cachedDestinations = await this.findClosestDestinations(
       tripLatLon.lat,
       tripLatLon.lng,
-      numberToFetch,
+      maxStagesToFetch,
     )
 
-    const minStagesPerDay = Math.floor(
-      cachedDestinations.length / tripData.numberOfDays,
-    )
-
-    if (minStagesPerDay < 1) {
+    if (cachedDestinations.length === 0) {
       return null
     }
 
     let index = 0
-    return {
-      days: Array.from({ length: tripData.numberOfDays }, (_, dayIndex) => {
-        let stageIndex = 0
-        const stages = Array.from({ length: minStagesPerDay }, () => {
-          const destination = cachedDestinations[index++]
-          stageIndex++
-          return {
-            stageIndex: stageIndex,
-            stageLocationName: destination.alias
-              ? destination.alias[0]
-              : destination.name,
-            stageDescription: destination.description,
-            stageEmoji: destination.emoji,
-          }
-        })
+    const s = []
 
-        return {
-          day: dayIndex + 1,
-          stages,
-        }
-      }),
+    while (index < cachedDestinations.length) {
+      const destination = cachedDestinations[index++]
+      s.push({
+        i: index,
+        l: destination.alias ? destination.alias[0] : destination.name,
+        d: destination.description,
+        e: destination.emoji,
+      })
     }
+
+    return { s }
   }
 
-  combineDestinations(cachedData, generatedData, numberOfDays) {
+  combineDestinations(
+    cachedStages,
+    generatedStages,
+    numberOfDays,
+    stagesPerDay,
+  ) {
     const combinedDestinations = []
+    const allStages = [...cachedStages.s, ...generatedStages.s]
+    let combinedStageIndex = 0
 
     for (let i = 0; i < numberOfDays; i++) {
-      const cachedStages = cachedData
-        ? cachedData.days[i]
-          ? cachedData.days[i].stages
-          : []
-        : []
-      const generatedStages = generatedData.days[i]
-        ? generatedData.days[i].stages
-        : []
+      const stagesForDay = []
+      let stageIndex = 0
 
-      const combinedStages = []
-
-      const allStages = [...cachedStages, ...generatedStages]
-
-      allStages.forEach((stage, index) => {
-        combinedStages.push({
-          // eslint-disable-next-line node/no-unsupported-features/es-syntax
-          ...stage,
-          stageIndex: index + 1,
-        })
-      })
+      for (let j = 0; j < stagesPerDay; j++) {
+        if (combinedStageIndex < allStages.length) {
+          const stage = allStages[combinedStageIndex++]
+          stageIndex++
+          stagesForDay.push({
+            stageIndex: stageIndex,
+            stageLocationName: stage.l,
+            stageDescription: stage.d,
+            stageEmoji: stage.e,
+          })
+        }
+      }
 
       combinedDestinations.push({
         day: i + 1,
-        stages: combinedStages,
+        stages: stagesForDay,
       })
     }
+    // combinedDestinations.forEach((day) => {
+    //   console.log(day.stages)
+    // })
 
     return {
       days: combinedDestinations,

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -1,42 +1,10 @@
 /* eslint-disable node/no-unsupported-features/es-syntax */
 const DestinationModel = require('../models/DestinationModel')
 const getLatLon = require('../googleapi/getLatLon')
-// const generateTrip = require('../openai/generateTrip')
 const generateDestination = require('../openai/generateDestination')
 const nlp = require('compromise')
-const FuzzySearch = require('fuzzy-search')
 
 class DestinationController {
-  async searchDestination(query) {
-    try {
-      // TODO: double check with coordinates
-      // Fetch all destinations
-      const destinations = await DestinationModel.find().lean()
-
-      // Extract names and aliases
-      const namesAndAliases = destinations.flatMap((destination) => [
-        destination.name,
-        ...(destination.alias || []),
-      ])
-
-      // Perform a fuzzy search on the names and aliases
-      const searcher = new FuzzySearch(namesAndAliases)
-      const results = searcher.search(query)
-
-      // Return the destinations that match the search results
-      const matchingDestinations = destinations.filter(
-        (destination) =>
-          results.includes(destination.name) ||
-          (destination.alias || []).some((alias) => results.includes(alias)),
-      )
-
-      return matchingDestinations
-    } catch (error) {
-      error.message = 'Could not search destination | ' + error.message
-      throw error
-    }
-  }
-
   async findClosestDestinations(latitude, longitude, n) {
     try {
       const milesToMeters = 1609.34 // Conversion factor
@@ -135,7 +103,6 @@ class DestinationController {
     return nouns
   }
 
-  // TODO: if there is tripNotes, then generate all
   /**
    * Generates a trip itinerary by combining cached and newly generated stages.
    * It first tries to fetch up to 80% of the whole trip as cached stages based on the trip data.

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -108,6 +108,7 @@ class DestinationController {
     }
   }
 
+  // this could possibly be used to fetch from cache even when user has tripNote
   extractTags(notes) {
     const doc = nlp(notes)
     let nouns = doc.nouns().out('array')
@@ -188,15 +189,15 @@ class DestinationController {
       tripData.numberOfDays * tripData.stagesPerDay * 0.8,
     )
 
+    if (maxStagesToFetch === 0) {
+      return null
+    }
+
     const cachedDestinations = await this.findClosestDestinations(
       tripLatLon.lat,
       tripLatLon.lng,
       maxStagesToFetch,
     )
-
-    if (cachedDestinations.length === 0) {
-      return null
-    }
 
     let index = 0
     const s = []

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -4,6 +4,7 @@ const FuzzySearch = require('fuzzy-search')
 class DestinationController {
   async searchDestination(query) {
     try {
+      // TODO: double check with coordinates
       // Fetch all destinations
       const destinations = await DestinationModel.find().lean()
 
@@ -33,6 +34,9 @@ class DestinationController {
 
   async findClosestDestinations(latitude, longitude, n) {
     try {
+      const milesToMeters = 1609.34 // Conversion factor
+      const maxDistance = 30 * milesToMeters // Limit search to 30 miles
+
       const closestDestinations = await DestinationModel.find({
         location: {
           $near: {
@@ -40,6 +44,7 @@ class DestinationController {
               type: 'Point',
               coordinates: [longitude, latitude],
             },
+            $maxDistance: maxDistance,
           },
         },
       })
@@ -49,6 +54,47 @@ class DestinationController {
       return closestDestinations
     } catch (error) {
       error.message = 'Could not find closest destinations | ' + error.message
+      throw error
+    }
+  }
+
+  async cacheStage(stage, name) {
+    try {
+      // TODO: dont cache dupe alias
+      // TODO: cache emoji and descriptions
+      // Find existing destination by coordinates
+      const existingDestination = await DestinationModel.findOne({
+        'location.coordinates': [stage.stageLongitude, stage.stageLatitude],
+      }).lean()
+
+      if (existingDestination) {
+        // Update existing destination with new alias and tags
+        existingDestination.alias = existingDestination.alias || []
+        existingDestination.alias.push(stage.stageLocation)
+
+        // TODO: Decipher description into tags
+        // existingDestination.tag = decipherTags(stage.description);
+
+        await DestinationModel.findByIdAndUpdate(
+          existingDestination._id,
+          existingDestination,
+        )
+      } else {
+        // Create new destination with given name and alias
+        const newDestination = {
+          location: {
+            coordinates: [stage.stageLongitude, stage.stageLatitude],
+          },
+          name: name,
+          alias: [stage.stageLocation],
+          // TODO: Decipher description into tags
+          // tag: decipherTags(stage.description),
+        }
+
+        await DestinationModel.create(newDestination)
+      }
+    } catch (error) {
+      error.message = 'Could not cache stage | ' + error.message
       throw error
     }
   }

--- a/server/controllers/DestinationController.js
+++ b/server/controllers/DestinationController.js
@@ -1,4 +1,5 @@
 const DestinationModel = require('../models/DestinationModel')
+const getLatLon = require('../googleapi/getLatLon')
 const FuzzySearch = require('fuzzy-search')
 
 class DestinationController {
@@ -32,6 +33,44 @@ class DestinationController {
     }
   }
 
+  async tryCache(tripData) {
+    const tripLatLon = await getLatLon(tripData.tripLocation)
+    const cachedDestinations = await this.findClosestDestinations(
+      tripLatLon.lat,
+      tripLatLon.lng,
+      tripData.numberOfDays * tripData.stagesPerDay,
+    )
+    if (
+      cachedDestinations.length >=
+      tripData.numberOfDays * tripData.stagesPerDay
+    ) {
+      return {
+        days: Array.from({ length: tripData.numberOfDays }, (_, dayIndex) => ({
+          day: dayIndex + 1,
+          stages: Array.from(
+            { length: tripData.stagesPerDay },
+            (_, stageIndex) => {
+              const destination =
+                cachedDestinations[
+                  dayIndex * tripData.stagesPerDay + stageIndex
+                ]
+              return {
+                stageIndex: stageIndex + 1,
+                stageLocationName: destination.alias
+                  ? destination.alias[0]
+                  : destination.name,
+                stageDescription: destination.description,
+                stageEmoji: destination.emoji,
+              }
+            },
+          ),
+        })),
+      }
+    } else {
+      return null
+    }
+  }
+
   async findClosestDestinations(latitude, longitude, n) {
     try {
       const milesToMeters = 1609.34 // Conversion factor
@@ -60,33 +99,25 @@ class DestinationController {
 
   async cacheStage(stage, name) {
     try {
-      // TODO: dont cache dupe alias
-      // TODO: cache emoji and descriptions
-      // Find existing destination by coordinates
       const existingDestination = await DestinationModel.findOne({
         'location.coordinates': [stage.stageLongitude, stage.stageLatitude],
       }).lean()
 
       if (existingDestination) {
-        // Update existing destination with new alias and tags
-        existingDestination.alias = existingDestination.alias || []
-        existingDestination.alias.push(stage.stageLocation)
-
-        // TODO: Decipher description into tags
-        // existingDestination.tag = decipherTags(stage.description);
-
-        await DestinationModel.findByIdAndUpdate(
-          existingDestination._id,
-          existingDestination,
-        )
+        await DestinationModel.findByIdAndUpdate(existingDestination._id, {
+          $addToSet: { alias: stage.stageLocation },
+          // TODO: Decipher description into tags
+          // tag: decipherTags(stage.description),
+        })
       } else {
-        // Create new destination with given name and alias
         const newDestination = {
           location: {
             coordinates: [stage.stageLongitude, stage.stageLatitude],
           },
           name: name,
           alias: [stage.stageLocation],
+          description: stage.description,
+          emoji: stage.emoji,
           // TODO: Decipher description into tags
           // tag: decipherTags(stage.description),
         }

--- a/server/controllers/TripController.js
+++ b/server/controllers/TripController.js
@@ -1,5 +1,6 @@
 const TripModel = require('../models/TripModel')
 const generateTripsMetadata = require('../openai/generateTripMetadata')
+const generateTrip = require('../openai/generateTrip')
 const getCoordinatesFromLocation = require('../googleapi/googleCoordinates')
 const DestinationController = require('./DestinationController')
 const mongoose = require('mongoose')
@@ -145,13 +146,17 @@ class TripController {
   }
 
   async generateAndSaveTrip(userId, tripData, id = null, session) {
-    let filteredTripData = tripData.colloquialPrompt
-      ? await generateTripsMetadata(tripData.colloquialPrompt)
-      : tripData
-
     try {
+      let filteredTripData = tripData.colloquialPrompt
+        ? await generateTripsMetadata(tripData.colloquialPrompt)
+        : tripData
+
       const generatedTripWithStages =
-        await this.destinationController.generateTripWithCache(filteredTripData)
+        tripData.tripNotes || tripData.colloquialPrompt
+          ? await generateTrip(filteredTripData)
+          : await this.destinationController.generateTripWithCache(
+              filteredTripData,
+            )
 
       const tripToSave = {
         tripName: filteredTripData.tripName,

--- a/server/controllers/TripController.js
+++ b/server/controllers/TripController.js
@@ -150,7 +150,11 @@ class TripController {
       ? await generateTripsMetadata(tripData.colloquialPrompt)
       : tripData
 
-    // TODO: 75-25
+    /**
+     * TODO:
+     *  if found enough, return 75% cache
+     *  if not found enough, return 100% cache
+     */
     let generatedTripWithStages = await this.destinationController.tryCache(
       filteredTripData,
     )
@@ -223,6 +227,7 @@ class TripController {
             this.destinationController.cacheStage(
               stage,
               filteredTripData.tripLocation,
+              filteredTripData.tripNotes,
             ),
           )
         } catch (error) {

--- a/server/controllers/TripController.js
+++ b/server/controllers/TripController.js
@@ -1,5 +1,4 @@
 const TripModel = require('../models/TripModel')
-const generateTrip = require('../openai/generateTrip')
 const generateTripsMetadata = require('../openai/generateTripMetadata')
 const getCoordinatesFromLocation = require('../googleapi/googleCoordinates')
 const DestinationController = require('./DestinationController')
@@ -150,24 +149,10 @@ class TripController {
       ? await generateTripsMetadata(tripData.colloquialPrompt)
       : tripData
 
-    /**
-     * TODO:
-     *  if found enough, return 75% cache
-     *  if not found enough, return 100% cache
-     */
-    let generatedTripWithStages = await this.destinationController.tryCache(
-      filteredTripData,
-    )
-    if (generatedTripWithStages === null) {
-      try {
-        generatedTripWithStages = await generateTrip(filteredTripData)
-      } catch (error) {
-        error.message = 'Error while generating trip | ' + error.message
-        throw error
-      }
-    }
-
     try {
+      const generatedTripWithStages =
+        await this.destinationController.generateTripWithCache(filteredTripData)
+
       const tripToSave = {
         tripName: filteredTripData.tripName,
         tripLocation: filteredTripData.tripLocation,

--- a/server/googleapi/getLatLon.js
+++ b/server/googleapi/getLatLon.js
@@ -1,0 +1,37 @@
+require('dotenv').config()
+const axios = require('axios')
+
+/**
+ Retrieves the coordinates of a stage location using Google Places API.
+ @see {@link https://developers.google.com/maps/documentation/javascript/places|Google Places API}
+ @param {string} destination - The destination.
+ @returns {object} { lat: number, lng: number }
+ @throws {Error} If there is an error while fetching place details.
+ */
+async function getLatLon(destination) {
+  const query = `${destination}`
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY
+  const url = 'https://maps.googleapis.com/maps/api/place/textsearch/json'
+
+  try {
+    const response = await axios.get(url, {
+      params: {
+        query: query,
+        inputtype: 'textquery',
+        fields: 'geometry',
+        key: apiKey,
+      },
+    })
+    if (!response.data.results.length) {
+      throw new Error('No coordinates found.')
+    }
+    const { location } = response.data.results[0].geometry
+
+    return location
+  } catch (error) {
+    error.message = 'Error while fetching place details | ' + error.message
+    throw error
+  }
+}
+
+module.exports = getLatLon

--- a/server/googleapi/googleCoordinates.js
+++ b/server/googleapi/googleCoordinates.js
@@ -15,12 +15,14 @@ async function getCoordinatesFromLocation(
   stageLocationName,
   includeRating,
 ) {
+  console.log()
   const query = `${stageLocationName} ${destinationCity}`
   const apiKey = process.env.GOOGLE_PLACES_API_KEY
   const url = 'https://maps.googleapis.com/maps/api/place/textsearch/json'
 
   try {
-    const response = await axios.get(url, {
+    let response
+    response = await axios.get(url, {
       params: {
         query: query,
         inputtype: 'textquery',
@@ -29,7 +31,18 @@ async function getCoordinatesFromLocation(
       },
     })
     if (!response.data.results.length) {
-      throw new Error('No coordinates found.')
+      console.log(destinationCity, stageLocationName)
+      // retry with just stageLocationName, sometimes it has city in it
+      response = await axios.get(url, {
+        params: {
+          query: `${stageLocationName}`,
+          inputtype: 'textquery',
+          fields: 'geometry',
+          key: apiKey,
+        },
+      })
+      if (!response.data.results.length)
+        throw new Error('No coordinates found.')
     }
     const { location } = response.data.results[0].geometry
     if (includeRating) {

--- a/server/googleapi/googleCoordinates.js
+++ b/server/googleapi/googleCoordinates.js
@@ -15,7 +15,6 @@ async function getCoordinatesFromLocation(
   stageLocationName,
   includeRating,
 ) {
-  console.log()
   const query = `${stageLocationName} ${destinationCity}`
   const apiKey = process.env.GOOGLE_PLACES_API_KEY
   const url = 'https://maps.googleapis.com/maps/api/place/textsearch/json'

--- a/server/middlewares/extraFeatureRateLimiter.js
+++ b/server/middlewares/extraFeatureRateLimiter.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-vars */
+const rateLimit = require('express-rate-limit')
+const config = require('../config/config')
+
+const extraFeatureLimiter = rateLimit({
+  windowMs: config.server.timeLimit,
+  max: config.server.efRateLimit,
+  message: `You have exceeded the ${config.server.efRateLimit} trip requests in 24 hours limit!`,
+  headers: true,
+  skipFailedRequests: true,
+  keyGenerator: (request) => {
+    return request.headers['true-client-ip'] || request.ip
+  },
+  requestWasSuccessful: (_, response) => {
+    return response.isExtraFeature && response.statusCode < 400
+  },
+  skip: (request, _) => {
+    return request.isAdmin || request.skipEF || config.server.env === 'TEST'
+  },
+})
+
+module.exports = extraFeatureLimiter

--- a/server/middlewares/rateLimiter.js
+++ b/server/middlewares/rateLimiter.js
@@ -15,16 +15,18 @@ const apiLimiter = rateLimit({
     return response.isTripAPI && response.statusCode < 400
   },
   skip: (request, _) => {
-    console.log('Host:', request.headers.host)
-    console.log('User-Agent:', request.headers['user-agent'])
-    console.log('Referer:', request.headers.referer)
-    console.log('CF-IPCountry:', request.headers['cf-ipcountry'])
-    console.log('X-Forwarded-Proto:', request.headers['x-forwarded-proto'])
-    console.log('X-Forwarded:', request.headers['x-forwarded-for'])
-    console.log('X-Request-Start:', request.headers['x-request-start'])
-    console.log('User ID:', request.userId)
-    console.log('Is Admin:', request.isAdmin)
-    console.log('Request Body:', request.body)
+    if (Object.keys(request.body).length !== 0) {
+      console.log('Host:', request.headers.host)
+      console.log('User-Agent:', request.headers['user-agent'])
+      console.log('Referer:', request.headers.referer)
+      console.log('CF-IPCountry:', request.headers['cf-ipcountry'])
+      console.log('X-Forwarded-Proto:', request.headers['x-forwarded-proto'])
+      console.log('X-Forwarded:', request.headers['x-forwarded-for'])
+      console.log('X-Request-Start:', request.headers['x-request-start'])
+      console.log('User ID:', request.userId)
+      console.log('Is Admin:', request.isAdmin)
+      console.log('Request Body:', request.body)
+    }
     return request.isAdmin || config.server.env === 'TEST'
   },
 })

--- a/server/models/DestinationModel.js
+++ b/server/models/DestinationModel.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose')
+
+const destinationSchema = new mongoose.Schema({
+  location: {
+    type: { type: String, default: 'Point' },
+    coordinates: { type: [Number], required: true }, // [longitude, latitude]
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  alias: [String],
+  rating: Number,
+  description: String,
+  emoji: String,
+  tag: String,
+})
+
+// Create a 2dsphere index on the location field
+destinationSchema.index({ location: '2dsphere' })
+
+module.exports = mongoose.model('Destination', destinationSchema)

--- a/server/models/DestinationModel.js
+++ b/server/models/DestinationModel.js
@@ -6,6 +6,7 @@ const destinationSchema = new mongoose.Schema({
     coordinates: { type: [Number], required: true }, // [longitude, latitude]
   },
   name: {
+    // usually city/country; the destination user gives
     type: String,
     required: true,
   },
@@ -13,7 +14,7 @@ const destinationSchema = new mongoose.Schema({
   rating: Number,
   description: String,
   emoji: String,
-  tag: String,
+  tag: [String],
 })
 
 // Create a 2dsphere index on the location field

--- a/server/openai/generateDestination.js
+++ b/server/openai/generateDestination.js
@@ -1,0 +1,62 @@
+const openaiClient = require('./openaiClient')
+
+async function generateDestination(constraints, locationsToAvoid = []) {
+  const totalPlaces = constraints.numberOfDays * constraints.stagesPerDay
+  if (totalPlaces > 25) {
+    throw new Error(
+      `Trips must have a maximum of 25 places (user requested ${totalPlaces} places)`,
+    )
+  }
+  const naturalLanguageConstraints = `
+      Destination: ${constraints.tripLocation}
+      Budget per Day: $${constraints.budget}
+      Number of Places: ${totalPlaces}
+      Specific Locations to Avoid: ${locationsToAvoid.join(', ')}
+   `
+  const conversation = [
+    {
+      role: 'system',
+      content: `You are an AI that generates travel itineraries. Respond with ONLY JSON that contains the plan for each stage. 
+        ONLY respond with the following format, do not include any descriptions or codeblocks, I should be able to parse the output to a JavaScript Object.
+        The response needs to be formatted exactly like the following structure and the 'l' (location's name) should be real places names such that Google Maps can find them:
+        '''
+        {
+          s: [
+            {
+              i: Number (the current index starting from 1),
+              l: String (the location's name),
+              d: String (best description around 25 words),
+              e: String  (best emoji representation of stage),
+            }
+          ]
+        }
+        '''
+        
+        If there are any confusing values respond with:
+        '''
+        {
+          error: String (reason)
+        }
+        '''
+        `,
+    },
+    {
+      role: 'user',
+      content: `Generate a travel itinerary based on these constraints: ${naturalLanguageConstraints}`,
+    },
+  ]
+
+  const tripJson = await openaiClient(conversation)
+  const response = JSON.parse(tripJson)
+
+  if (!response) {
+    throw new Error(
+      'Unable to generate a travel itinerary. Please try again later.',
+    )
+  } else if (response.error) {
+    throw new Error(response.error)
+  }
+  return response
+}
+
+module.exports = generateDestination

--- a/server/openai/generateDestination.js
+++ b/server/openai/generateDestination.js
@@ -25,7 +25,7 @@ async function generateDestination(constraints, locationsToAvoid = []) {
             {
               i: Number (the current index starting from 1),
               l: String (the location's name),
-              d: String (best description around 25 words),
+              d: String (best description less than 25 words),
               e: String  (best emoji representation of stage),
             }
           ]

--- a/server/openai/generateTrip.js
+++ b/server/openai/generateTrip.js
@@ -30,7 +30,6 @@ const openaiClient = require('./openaiClient')
  *           stageLocationName: String,
  *           stageDescription: String,
  *           stageEmoji: String (best emoji representation of stage),
- *           stageColor: Number (Random number between 1-17)
  *         }
  *       ]
  *     }

--- a/server/openai/generateTrip.js
+++ b/server/openai/generateTrip.js
@@ -63,16 +63,11 @@ async function generateTrip(constraints, locationsToAvoid = []) {
         The response needs to be formatted exactly like the following structure and the stageLocationName should be real places names such that Google Maps can find them:
         '''
         {
-          days:[
+          days: [
             {
-              day: Number
-              stages:[
-                {
-                  stageIndex: Number,
-                  stageLocationName: String,
-                  stageDescription: String,
-                  stageEmoji: String (best emoji representation of stage),
-                }
+              n: Number (the current index starting from 1),
+              s: [
+                [Number (the current index starting from 1), String (the location's name), String (best description less than 25 words), String (best emoji representation of stage)]
               ]
             }
           ]
@@ -103,7 +98,32 @@ async function generateTrip(constraints, locationsToAvoid = []) {
   } else if (response.error) {
     throw new Error(response.error)
   }
-  return response
+  return convertToFullForm(response)
 }
 
+function convertToFullForm(currentForm) {
+  if (!currentForm || !currentForm.days) {
+    return {
+      error: 'Invalid input format',
+    }
+  }
+
+  const desiredForm = {
+    days: currentForm.days.map((day) => {
+      return {
+        day: day.n,
+        stages: day.s.map((stage) => {
+          return {
+            stageIndex: stage[0],
+            stageLocationName: stage[1],
+            stageDescription: stage[2],
+            stageEmoji: stage[3],
+          }
+        }),
+      }
+    }),
+  }
+
+  return desiredForm
+}
 module.exports = generateTrip

--- a/server/openai/generateTrip.js
+++ b/server/openai/generateTrip.js
@@ -65,9 +65,9 @@ async function generateTrip(constraints, locationsToAvoid = []) {
         {
           days: [
             {
-              n: Number (the current index starting from 1),
+              n: Number (the current day index starting from 1),
               s: [
-                [Number (the current index starting from 1), String (the location's name), String (best description less than 25 words), String (best emoji representation of stage)]
+                [Number (the current stage index starting from 1), String (the location's name), String (best description less than 25 words), String (best emoji representation of stage)]
               ]
             }
           ]

--- a/server/openai/generateTrip.js
+++ b/server/openai/generateTrip.js
@@ -7,6 +7,7 @@ const openaiClient = require('./openaiClient')
  *
  * @async
  * @param {Object} constraints TripModel Object - The travel constraints.
+ * @param {Object} locationsToAvoid - specifies the places to avoid, optional and defaults to []
  * @param {string} constraints.tripLocation - The destination of the trip.
  * @param {number} constraints.budget - The budget per day for the trip.
  * @param {number} constraints.numberOfDays - The number of days for the trip.
@@ -41,7 +42,7 @@ const openaiClient = require('./openaiClient')
  * }
  * @throws Will throw an error if the openaiClient or AI response fails.
  */
-async function generateTrip(constraints) {
+async function generateTrip(constraints, locationsToAvoid = []) {
   const totalPlaces = constraints.numberOfDays * constraints.stagesPerDay
   if (totalPlaces > 25) {
     throw new Error(
@@ -53,6 +54,7 @@ async function generateTrip(constraints) {
       Budget per Day: $${constraints.budget}
       Days: ${constraints.numberOfDays}
       Stages per Day: ${constraints.stagesPerDay}
+      Specific locations to avoid: ${locationsToAvoid.join(', ')}
    `
   const conversation = [
     {

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.4.0",
     "bcryptjs": "^2.4.3",
     "chalk": "4.1.2",
+    "compromise": "^14.10.0",
     "concurrently": "^8.0.1",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,6 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-rate-limit": "^6.8.1",
-    "fuzzy-search": "^3.2.1",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^5.5.0",
     "mongoose": "^7.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-rate-limit": "^6.8.1",
+    "fuzzy-search": "^3.2.1",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^5.5.0",
     "mongoose": "^7.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "reset:db": "node scripts/resetDB.js",
     "populate:db": "node scripts/populateDB.js",
     "dupe:db": "node scripts/dupeDB.js",
+    "cache:db": "node scripts/cacheStages.js",
     "coordinates:test": "node googleapi/getCoordinateTest.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --cache --fix",

--- a/server/routes/UserRoute.js
+++ b/server/routes/UserRoute.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const controllers = require('../controllers/Controllers')
 const apiLimiter = require('../middlewares/rateLimiter')
+const extraFeatureLimiter = require('../middlewares/extraFeatureRateLimiter')
 
 class UserRoute {
   constructor() {
@@ -11,6 +12,11 @@ class UserRoute {
     this.router.post('/register', apiLimiter, this.register.bind(this))
     this.router.post('/login', this.login.bind(this))
     this.router.get('/limit-left', apiLimiter, this.fetchLimitLeft.bind(this))
+    this.router.get(
+      '/ef-limit-left',
+      extraFeatureLimiter,
+      this.fetchEFLimitLeft.bind(this),
+    )
   }
 
   initRoutes(apiRouter) {
@@ -20,6 +26,18 @@ class UserRoute {
     try {
       const response = {
         attemptLeft: req.rateLimit.remaining + 1,
+      }
+
+      res.isTripAPI = false
+      res.json(response)
+    } catch (err) {
+      next(err)
+    }
+  }
+  async fetchEFLimitLeft(req, res, next) {
+    try {
+      const response = {
+        efAttemptLeft: req.rateLimit.remaining + 1,
       }
 
       res.isTripAPI = false

--- a/server/scripts/cacheStages.js
+++ b/server/scripts/cacheStages.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose')
+const config = require('../config/config')
+const Stage = require('../models/StageModel')
+const DestinationController = require('../controllers/DestinationController')
+
+const cacheStages = async () => {
+  try {
+    await mongoose.connect(config.mongo.uri)
+    console.log('Connected to database...')
+
+    const stages = await Stage.find({}).lean()
+
+    const destinationController = new DestinationController()
+
+    for (const stage of stages) {
+      await destinationController.cacheStage(stage, stage.stageLocation, null)
+    }
+
+    console.log('All stages cached.')
+  } catch (err) {
+    console.error(err)
+  } finally {
+    await mongoose.connection.close()
+  }
+}
+
+cacheStages()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3846,6 +3846,15 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compromise@^14.10.0:
+  version "14.10.0"
+  resolved "https://registry.yarnpkg.com/compromise/-/compromise-14.10.0.tgz#832570faed00aee84c917131ac45e20e8162f9a6"
+  integrity sha512-ViDNmO4N8xezb6NKYWUUcOckWE9tYEi5Yr2AYN2L5MaJCSMmwLRmgdajpN5u1snNOmg/RdJ37fONQ2+fd4UPfQ==
+  dependencies:
+    efrt "2.7.0"
+    grad-school "0.0.5"
+    suffix-thumb "5.0.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
@@ -4518,6 +4527,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
+efrt@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/efrt/-/efrt-2.7.0.tgz#8b021e69f75cfeed3f81ee058aa0c78265793324"
+  integrity sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==
 
 ejs@^3.1.6:
   version "3.1.9"
@@ -5748,6 +5762,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+grad-school@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/grad-school/-/grad-school-0.0.5.tgz#9e7b2084f3e137965c19b63ef0dfe49867194f43"
+  integrity sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==
 
 grapheme-splitter@^1.0.4:
   version "1.0.4"
@@ -10077,6 +10096,11 @@ sucrase@^3.32.0:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
+
+suffix-thumb@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/suffix-thumb/-/suffix-thumb-5.0.2.tgz#b38940faddb3ae8b5fd281c7ec5830c25a6b2c9c"
+  integrity sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==
 
 supercluster@^8.0.0:
   version "8.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,11 +5591,6 @@ functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-fuzzy-search@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/fuzzy-search/-/fuzzy-search-3.2.1.tgz#65d5faad6bc633aee86f1898b7788dfe312ac6c9"
-  integrity sha512-vAcPiyomt1ioKAsAL2uxSABHJ4Ju/e4UeDM+g1OlR0vV4YhLGMNsdLNvZTpEDY4JCSt0E4hASCNM5t2ETtsbyg==
-
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,6 +5577,11 @@ functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fuzzy-search@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/fuzzy-search/-/fuzzy-search-3.2.1.tgz#65d5faad6bc633aee86f1898b7788dfe312ac6c9"
+  integrity sha512-vAcPiyomt1ioKAsAL2uxSABHJ4Ju/e4UeDM+g1OlR0vV4YhLGMNsdLNvZTpEDY4JCSt0E4hASCNM5t2ETtsbyg==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"


### PR DESCRIPTION
- limit left is always fetched from server instead of relying on redux, and the alert doesnt spam when u spam open the modals
- new limit for the Extra Notes and Speak Your Mind. one per day since they are the features that cannot be used with cache rn
- new model called Destination which uses Mongo 2dsphere index to cache stages
- when creating new trips (without Extra Notes and Speak Your Mind), it will try to fill in 80% with cache, whatever is left will be generated. however the new generation response is shorter (it just generates a list of stages and then it is built into the usual format)
- generateTrip response is shorten, then it is built to the usual form.
- googleCoordinates retry once because most of the errors come from when the stageLocationName has city in it. eg. 'Stanley Park, Vancouver'
- script to turn current stages in db to destinations